### PR TITLE
use HTTPS url for Wikipedia API

### DIFF
--- a/autocomplete/autocomplete.js
+++ b/autocomplete/autocomplete.js
@@ -3,7 +3,7 @@
     // Search Wikipedia for a given term
     function searchWikipedia(term) {
         var cleanTerm = global.encodeURIComponent(term);
-        var url = 'http://en.wikipedia.org/w/api.php?action=opensearch&format=json&search='
+        var url = 'https://en.wikipedia.org/w/api.php?action=opensearch&format=json&search='
             + cleanTerm + '&callback=JSONPCallback';
         return Rx.Observable.getJSONPRequest(url);
     }


### PR DESCRIPTION
Github serves his pages over HTTPS, and requesting HTTP from HTTPS pages disallowed in modern browsers (tested in Firefox 35 and Chromium 39):

    Mixed Content: The page at
    'https://reactive-extensions.github.io/RxJS-Examples/autocomplete/autocomplete.html'
    was loaded over HTTPS, but requested an insecure script
    'http://en.wikipedia.org/w/api.php?action=opensearch&format=json&search=test&callback=rxjscallback0'.
    This request has been blocked; the content must be served over HTTPS.