### PR TITLE
Fix autocomplete based on the new Wikipedia opensearch result format

### DIFF
--- a/autocomplete/autocomplete.js
+++ b/autocomplete/autocomplete.js
@@ -35,7 +35,7 @@
         })
         .switchLatest() // Ensure no out of order results
         .where(function (data) {
-            return data.length === 2; // Where we have data
+            return data.length >= 2; // Where we have data
         });
 
         searcher.subscribe(function (data) {


### PR DESCRIPTION
The autocomplete example was broken, because Wikiepdia opensearch API now returns an array containing 4 elements instead of 2.